### PR TITLE
Relax version requirement for `js` dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  js: ^0.6.7
+  js: ^0.6.5
 
 dev_dependencies:
   build_runner: '>=2.3.3'


### PR DESCRIPTION
This makes it compatible with projects on flutter version 3.70 and above. This is the lowest version that supports dart 2.19.0.

Side note, is there any reason for the dart dependency to be so strict?